### PR TITLE
Support for composer and Plugins

### DIFF
--- a/Config/bootstrap.php
+++ b/Config/bootstrap.php
@@ -12,7 +12,7 @@
 
 
 /* ------ Execute --------*/
-AutoAppBuild::build();
+//AutoAppBuild::build();
 //AutoAppBuild::dump();
 
 
@@ -58,7 +58,10 @@ class AutoAppBuild {
 /**
  * execute App::build 
  **/
-	public static function build() {
+	public static function build($plugin = null) {
+		if($plugin != null){
+			self::$appDir = CakePlugin::path($plugin);
+		}
 		self::setAppPath();
 
 		foreach(self::$list as $target => $path) {

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,17 @@
+{
+  "name": "ichikaway/autoappbuild",
+  "type": "cakephp-plugin",
+  "version": "0.1",
+  "description": "Automatic App::build Plugin for CakePHP",
+  "keywords": ["cakephp"],
+  "homepage": "https://github.com/ichikaway/AutoAppBuild",
+  "license": "MIT",
+  "authors": [
+    {
+      "name": "Yasushi Ichikawa "
+    }
+  ],
+  "require": {
+    "composer/installers": "*"
+  }
+}


### PR DESCRIPTION
Support for composer, also support for external plugins who want to use App::build instead of only the APP folder.
Note: this functionality is only compatible with pull request https://github.com/cakephp/cakephp/pull/5657
